### PR TITLE
Fix/normalize ghost domain input

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,6 +24,8 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew clean androidApp:assembleDebug
+    - name: Tests
+      run: ./gradlew :androidApp:test
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v4.6.2
       with:

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -44,6 +44,10 @@ android {
             jvmTarget.set(JvmTarget.JVM_17)
         }
     }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -68,4 +72,7 @@ dependencies {
     implementation(libs.androidx.paging.compose)
 
     debugImplementation(libs.compose.ui.tooling)
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation(kotlin("test"))
 }

--- a/androidApp/src/main/java/com/ghostly/android/login/LoginViewModel.kt
+++ b/androidApp/src/main/java/com/ghostly/android/login/LoginViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ghostly.android.utils.isValidEmail
 import com.ghostly.android.utils.isValidGhostDomain
+import com.ghostly.android.utils.normalizeGhostDomainInput
 import com.ghostly.datastore.DataStoreConstants
 import com.ghostly.datastore.DataStoreRepository
 import com.ghostly.datastore.LoginDetailsStore
@@ -123,7 +124,9 @@ class LoginViewModel(
     }
 
     suspend fun getSiteDetails() {
-        when (val result = getSiteDetailsUseCase.invoke(domain.value)) {
+        val normalized = normalizeGhostDomainInput(domain.value)
+        _domain.value = normalized
+        when (val result = getSiteDetailsUseCase.invoke(normalized)) {
             is Result.Success -> {
                 result.data?.siteDetails?.title?.let {
                     dataStoreRepository.putString(

--- a/androidApp/src/main/java/com/ghostly/android/utils/Strings.kt
+++ b/androidApp/src/main/java/com/ghostly/android/utils/Strings.kt
@@ -4,14 +4,41 @@ import android.util.Patterns
 import java.util.Locale
 import java.util.regex.Pattern
 
-private val GHOST_DOMAIN =
-    Pattern.compile("^https?://((?!-)[A-Za-z0–9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,6}/ghost\$")
+// Accepts hosts with or without scheme and optional trailing /ghost
+// Examples accepted:
+// - blog.example.com
+// - https://blog.example.com
+// - https://blog.example.com/ghost
+// - http://blog.example.com/ghost
+private val RELAXED_GHOST_DOMAIN = Pattern.compile(
+    "^(?:(?:https?)://)?" +
+            "((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+" +
+            "[A-Za-z]{2,}(?:/ghost)?/?$"
+)
 
 fun isValidEmail(target: CharSequence?): Boolean =
     target?.let { Patterns.EMAIL_ADDRESS.matcher(it).matches() } == true
 
 fun isValidGhostDomain(target: CharSequence?): Boolean =
-    target?.let { GHOST_DOMAIN.matcher(it).matches() } == true
+    target?.let { RELAXED_GHOST_DOMAIN.matcher(it.trim()).matches() } == true
+
+fun normalizeGhostDomainInput(input: String): String {
+    // Trim and ensure scheme and trailing /ghost
+    var url = input.trim()
+    if (url.isEmpty()) return url
+
+    if (!url.startsWith("http://") && !url.startsWith("https://")) {
+        url = "https://$url"
+    }
+
+    // Remove any trailing slashes to standardize, then append /ghost
+    url = url.removeSuffix("/")
+    if (!url.endsWith("/ghost")) {
+        url = "$url/ghost"
+    }
+
+    return url
+}
 
 fun String.capitalize(): String =
     this.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }

--- a/androidApp/src/main/java/com/ghostly/android/utils/Strings.kt
+++ b/androidApp/src/main/java/com/ghostly/android/utils/Strings.kt
@@ -4,12 +4,6 @@ import android.util.Patterns
 import java.util.Locale
 import java.util.regex.Pattern
 
-// Accepts hosts with or without scheme and optional trailing /ghost
-// Examples accepted:
-// - blog.example.com
-// - https://blog.example.com
-// - https://blog.example.com/ghost
-// - http://blog.example.com/ghost
 private val RELAXED_GHOST_DOMAIN = Pattern.compile(
     "^(?:(?:https?)://)?" +
             "((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+" +
@@ -23,7 +17,6 @@ fun isValidGhostDomain(target: CharSequence?): Boolean =
     target?.let { RELAXED_GHOST_DOMAIN.matcher(it.trim()).matches() } == true
 
 fun normalizeGhostDomainInput(input: String): String {
-    // Trim and ensure scheme and trailing /ghost
     var url = input.trim()
     if (url.isEmpty()) return url
 
@@ -31,7 +24,6 @@ fun normalizeGhostDomainInput(input: String): String {
         url = "https://$url"
     }
 
-    // Remove any trailing slashes to standardize, then append /ghost
     url = url.removeSuffix("/")
     if (!url.endsWith("/ghost")) {
         url = "$url/ghost"

--- a/androidApp/src/main/java/com/ghostly/android/utils/Strings.kt
+++ b/androidApp/src/main/java/com/ghostly/android/utils/Strings.kt
@@ -5,7 +5,7 @@ import java.util.Locale
 import java.util.regex.Pattern
 
 private val RELAXED_GHOST_DOMAIN = Pattern.compile(
-    "^(?:(?:https?)://)?" +
+    "^(?:https?://)?" +
             "((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+" +
             "[A-Za-z]{2,}(?:/ghost)?/?$"
 )

--- a/androidApp/src/test/java/com/ghostly/android/utils/StringsTest.kt
+++ b/androidApp/src/test/java/com/ghostly/android/utils/StringsTest.kt
@@ -8,12 +8,12 @@ import org.junit.Test
 class StringsTest {
     @Test
     fun `isValidGhostDomain accepts hostname without scheme`() {
-        assertTrue(isValidGhostDomain("blog.example.com"))
+        assertTrue(isValidGhostDomain("blog.example97.com"))
     }
 
     @Test
     fun `isValidGhostDomain accepts https with no ghost path`() {
-        assertTrue(isValidGhostDomain("https://blog.example.com"))
+        assertTrue(isValidGhostDomain("https://blog.example97.net"))
     }
 
     @Test

--- a/androidApp/src/test/java/com/ghostly/android/utils/StringsTest.kt
+++ b/androidApp/src/test/java/com/ghostly/android/utils/StringsTest.kt
@@ -1,0 +1,49 @@
+package com.ghostly.android.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StringsTest {
+    @Test
+    fun `isValidGhostDomain accepts hostname without scheme`() {
+        assertTrue(isValidGhostDomain("blog.example.com"))
+    }
+
+    @Test
+    fun `isValidGhostDomain accepts https with no ghost path`() {
+        assertTrue(isValidGhostDomain("https://blog.example.com"))
+    }
+
+    @Test
+    fun `isValidGhostDomain accepts https with ghost path`() {
+        assertTrue(isValidGhostDomain("https://blog.example.com/ghost"))
+    }
+
+    @Test
+    fun `normalizeGhostDomainInput ensures https and ghost path`() {
+        assertEquals(
+            "https://blog.example.com/ghost",
+            normalizeGhostDomainInput("blog.example.com")
+        )
+        assertEquals(
+            "https://blog.example.com/ghost",
+            normalizeGhostDomainInput("https://blog.example.com/")
+        )
+        assertEquals(
+            "https://blog.example.com/ghost",
+            normalizeGhostDomainInput("https://blog.example.com/ghost")
+        )
+    }
+
+    @Test
+    fun `isValidGhostDomain rejects invalid inputs`() {
+        assertFalse(isValidGhostDomain("http://"))
+        assertFalse(isValidGhostDomain("example"))
+        assertFalse(isValidGhostDomain("ftp://blog.example.com"))
+        assertFalse(isValidGhostDomain(""))
+        assertFalse(isValidGhostDomain("   "))
+    }
+}
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,16 +1,17 @@
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 pluginManagement {
     repositories {
+        mavenCentral()
         google()
         gradlePluginPortal()
-        mavenCentral()
     }
 }
 
 dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
     repositories {
-        google()
         mavenCentral()
+        google()
     }
 }
 


### PR DESCRIPTION
Fixes #17

Relax Ghost domain validation to accept optional scheme and optional /ghost. Normalize to https://<host>/ghost before fetching details. Removed inline comments.